### PR TITLE
Event based messaging

### DIFF
--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -44,6 +45,7 @@
     <Compile Include="ArmorGloves.cs" />
     <Compile Include="ArmorHelm.cs" />
     <Compile Include="ArmorPants.cs" />
+    <Compile Include="EventArgs\GameMessageEventArgs.cs" />
     <Compile Include="HealingPotion.cs" />
     <Compile Include="Interfaces\IHealingPotion.cs" />
     <Compile Include="Interfaces\IItem.cs" />
@@ -65,6 +67,7 @@
     <Compile Include="QuestCompletionItem.cs" />
     <Compile Include="Quest.cs" />
     <Compile Include="RandomNumberGenerator.cs" />
+    <Compile Include="Utilities\MessageUtilities.cs" />
     <Compile Include="Weapon.cs" />
     <Compile Include="World.cs" />
   </ItemGroup>

--- a/Engine/EventArgs/GameMessageEventArgs.cs
+++ b/Engine/EventArgs/GameMessageEventArgs.cs
@@ -1,0 +1,23 @@
+﻿using System.Drawing;
+
+namespace Engine.EventArgs
+{
+    public class GameMessageEventArgs
+    {
+        public string Message { get; set; }
+        public bool AddNewLine { get; set; }
+        public Color Color { get; set; }
+        public GameMessageEventArgs(string message, bool addNewLine = false)
+        {
+            Message = message;
+            AddNewLine = addNewLine;
+        }
+
+        public GameMessageEventArgs(string message, Color color, bool addNewLine)
+        {
+            Message = message;
+            Color = color;
+            AddNewLine = addNewLine;
+        }
+    }
+}

--- a/Engine/Utilities/MessageUtilities.cs
+++ b/Engine/Utilities/MessageUtilities.cs
@@ -1,0 +1,28 @@
+﻿using Engine.EventArgs;
+using System;
+using System.Drawing;
+
+namespace Engine.Utilities
+{
+    public class MessageUtilities
+    {
+        public event EventHandler<GameMessageEventArgs> OnMessageRaised;
+
+        public void RaiseMessage(string message, bool addExtraNewLine = false)
+        {
+            OnMessageRaised?.Invoke(this, new GameMessageEventArgs(message, addExtraNewLine));
+        }
+
+        public void RaiseWarning(string message, bool addExtraNewLine = false)
+        {
+            Color color = Color.Red;
+            OnMessageRaised?.Invoke(this, new GameMessageEventArgs(message, color, addExtraNewLine));
+        }
+
+        public void RaiseInfo(string message, bool addExtraNewLine = false)
+        {
+            Color color = Color.Blue;
+            OnMessageRaised?.Invoke(this, new GameMessageEventArgs(message, color, addExtraNewLine));
+        }
+    }
+}

--- a/SuperAdventure/Messages/CombatMessager.cs
+++ b/SuperAdventure/Messages/CombatMessager.cs
@@ -1,44 +1,44 @@
-﻿using Engine;
+﻿using Engine.Utilities;
+using Engine;
 using System;
 using System.Drawing;
 using Extensions;
-using SuperAdventure.Processes;
 
 namespace SuperAdventure.Messages
 {
-    public class CombatMessager
+    public class CombatMessager : MessageUtilities
     {
         private readonly SuperAdventure _superAdventure;
 
         public CombatMessager(SuperAdventure superAdventure)
         {
             _superAdventure = superAdventure;
+            OnMessageRaised += _superAdventure.DisplayMessage;
         }
 
         public void DisplayVictoryText()
         {
-            _superAdventure.rtbMessages.AppendText(Environment.NewLine);
-            _superAdventure.rtbMessages.AppendText("You've defeated the " + _superAdventure._combatProcessor._currentMonster.Name + ".", true);
-            _superAdventure.rtbMessages.AppendText("Gained: ", true);
-            _superAdventure.rtbMessages.AppendText(_superAdventure._combatProcessor._currentMonster.RewardExperiencePoints + " experience", true);
-            _superAdventure.rtbMessages.AppendText(_superAdventure._combatProcessor._currentMonster.RewardGold + " gold", true);
+            RaiseInfo("You've defeated the " + _superAdventure._combatProcessor._currentMonster.Name + ".", true);
+            RaiseMessage("Gained: ");
+            RaiseMessage(_superAdventure._combatProcessor._currentMonster.RewardExperiencePoints + " experiene");
+            RaiseMessage(_superAdventure._combatProcessor._currentMonster.RewardGold + " gold");
         }
 
         public void MonsterSpottedMessage(ILocation newLocation)
         {
-            _superAdventure.rtbMessages.AppendText(Environment.NewLine);
-            _superAdventure.rtbMessages.AppendText("You see a " + newLocation.MonsterLivingHere.Name, true);
+            RaiseMessage("");
+            RaiseInfo("You see a " + newLocation.MonsterLivingHere.Name, true);
         }
 
         public void LootMessage(InventoryItem inventoryItem)
         {
             if (inventoryItem.Quantity == 1)
             {
-                _superAdventure.rtbMessages.AppendText("You loot " + inventoryItem.Quantity.ToString() + " " + inventoryItem.Item.Name, true);
+                RaiseMessage("You loot " + inventoryItem.Quantity.ToString() + " " + inventoryItem.Item.Name);
             }
             else
             {
-                _superAdventure.rtbMessages.AppendText("You loot " + inventoryItem.Quantity.ToString() + " " + inventoryItem.Item.NamePlural, true);
+                RaiseMessage("You loot " + inventoryItem.Quantity.ToString() + " " + inventoryItem.Item.NamePlural);
             }
         }
 
@@ -46,13 +46,14 @@ namespace SuperAdventure.Messages
         {
             if (damageToMonster <= 0)
             {
-                _superAdventure.rtbMessages.AppendText(Environment.NewLine + "You have missed.", true);
+                RaiseInfo("You have missed.");
             }
             else
             {
-                string playerDPS = Environment.NewLine + "You've hit the "
-                                                       + _superAdventure._combatProcessor._currentMonster.Name + " for " + damageToMonster.ToString() + " damage.";
-                _superAdventure.rtbMessages.AppendText(playerDPS, Color.Blue, true);
+                string playerDPS = "You've hit the "
+                                 + _superAdventure._combatProcessor._currentMonster.Name 
+                                 + " for " + damageToMonster.ToString() + " damage.";
+                RaiseInfo(playerDPS);
             }
         }
 
@@ -63,16 +64,16 @@ namespace SuperAdventure.Messages
 
             if (damageToPlayer >= 1)
             {
-                _superAdventure.rtbMessages.AppendText(mobDPS, Color.Red, true);
+                RaiseWarning(mobDPS, true);
             }
             else
             {
-                _superAdventure.rtbMessages.AppendText("The " + _superAdventure._combatProcessor._currentMonster.Name + " has missed.", true);
+                RaiseWarning("The " + _superAdventure._combatProcessor._currentMonster.Name + " has missed.", true);
             }
 
             if (_superAdventure.player.CurrentHitPoints <= 0)
             {
-                _superAdventure.rtbMessages.AppendText(Environment.NewLine + "You have died.", true);
+                RaiseWarning(Environment.NewLine + "You have died.", true);
             }
         }
     }

--- a/SuperAdventure/Messages/QuestMessager.cs
+++ b/SuperAdventure/Messages/QuestMessager.cs
@@ -1,51 +1,42 @@
 ﻿using Engine;
+using Engine.Utilities;
 using System;
 
 namespace SuperAdventure.Messages
 {
-    public class QuestMessager
+    public class QuestMessager : MessageUtilities
     {
         private readonly SuperAdventure _superAdventure;
         public QuestMessager(SuperAdventure superAdventure)
         {           
             _superAdventure = superAdventure;
+            OnMessageRaised += _superAdventure.DisplayMessage;
         }
 
         public void ReceiveQuestMessage(ILocation location)
         {
-            _superAdventure.rtbMessages.AppendText(Environment.NewLine);
-            _superAdventure.rtbMessages.AppendText("You receive the " + location.QuestAvailableHere.Name + " quest");
-            _superAdventure.rtbMessages.AppendText(Environment.NewLine);
-            _superAdventure.rtbMessages.AppendText(location.QuestAvailableHere.Description);
-            _superAdventure.rtbMessages.AppendText(Environment.NewLine);
-            _superAdventure.ScrollToBottomOfMessages();
+            RaiseInfo("");
+            RaiseInfo("You receive the " + location.QuestAvailableHere.Name + " quest");
+            RaiseInfo(location.QuestAvailableHere.Description, true);
         }
 
         public void CompleteQuestMessage(ILocation location)
         {
-            _superAdventure.rtbMessages.AppendText(Environment.NewLine);
-            _superAdventure.rtbMessages.AppendText("You have completed the " + location.QuestAvailableHere.Name + " quest.");
-            _superAdventure.rtbMessages.AppendText(Environment.NewLine);
-            _superAdventure.ScrollToBottomOfMessages();
+            RaiseInfo("You have completed the " + location.QuestAvailableHere.Name + " quest.");
         }
 
         public void RewardQuestMessage(ILocation location)
         {
-            _superAdventure.rtbMessages.AppendText(Environment.NewLine);
-            _superAdventure.rtbMessages.AppendText("You receive: ");
-            _superAdventure.rtbMessages.AppendText(Environment.NewLine);
-            _superAdventure.rtbMessages.AppendText(location.QuestAvailableHere.RewardExperiencePoints.ToString() + " experience points");
-            _superAdventure.rtbMessages.AppendText(Environment.NewLine);
-            _superAdventure.rtbMessages.AppendText(location.QuestAvailableHere.RewardGold.ToString() + " gold");
-            _superAdventure.rtbMessages.AppendText(Environment.NewLine);
+            RaiseMessage("You receive: ");
+            RaiseMessage(location.QuestAvailableHere.RewardExperiencePoints.ToString() + " experience points");
+            RaiseMessage(location.QuestAvailableHere.RewardGold.ToString() + " gold");
 
             if (location.QuestAvailableHere.RewardItem != null)
             {
-                _superAdventure.rtbMessages.AppendText("and a " + location.QuestAvailableHere.RewardItem.Name);
-                _superAdventure.rtbMessages.AppendText(Environment.NewLine);
+                RaiseMessage("and a " + location.QuestAvailableHere.RewardItem.Name);
             }
 
-            _superAdventure.ScrollToBottomOfMessages();
+            RaiseMessage("");
         }
     }
 }

--- a/SuperAdventure/Processes/CombatProcessor.cs
+++ b/SuperAdventure/Processes/CombatProcessor.cs
@@ -56,7 +56,6 @@ namespace SuperAdventure.Processes
             foreach (InventoryItem inventoryItem in lootedItems)
             {
                 _superAdventure.player.AddItemToInventory(inventoryItem.Item);
-
                 _superAdventure._combatMessager.LootMessage(inventoryItem);
             }
         }

--- a/SuperAdventure/SuperAdventure.cs
+++ b/SuperAdventure/SuperAdventure.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
 using Engine;
+using Engine.EventArgs;
 using Extensions;
 using SuperAdventure.Messages;
 using SuperAdventure.Processes;
@@ -12,6 +13,7 @@ namespace SuperAdventure
     public partial class SuperAdventure : Form
     {
         public Player player;
+        //private MessageHandler _gameMessageHandler = new MessageHandler();
         private CharacterStatistics _charStatistics;
         private readonly QuestMessager _questMessager;
         private readonly QuestProcessor _questProcessor;
@@ -20,6 +22,8 @@ namespace SuperAdventure
 
         public bool charStatisticIsOpen = false;
         public new virtual RightToLeft Right { get; set; }
+
+        //public event EventHandler<GameMessageEventArgs> OnMessageRaised;
 
         public SuperAdventure()
         {
@@ -31,6 +35,7 @@ namespace SuperAdventure
             _combatProcessor = new CombatProcessor(this);
             _charStatistics = new CharacterStatistics(this);
             player = new Player(20, 1, 0, 1, 1, 1, 0, 10, 10);
+            //OnMessageRaised += DisplayMessage;
             MoveTo(World.LocationByID(World.LOCATION_ID_HOME));
             SetInventoryUI();
             UpdatePlayerStats();
@@ -38,6 +43,9 @@ namespace SuperAdventure
             dgvQuests.MouseWheel += new MouseEventHandler(dgvQuests_MouseWheel);
             this.Move += new EventHandler(MoveSubForm);
             this.Resize += new EventHandler(MoveSubForm);
+            //RaiseInformation("Pewwwwww");
+            //RaiseWarning("Meeeeeeeeow", Color.Red);
+            //RaiseWarning("fuuuuu", Color.Blue);
         }
 
         private void SuperAdventure_Load(object sender, EventArgs e)
@@ -52,6 +60,43 @@ namespace SuperAdventure
         private void rtbMessages_TextChanged(object sender, EventArgs e)
         {
             DeleteMessagesRowOverflow();
+            ScrollToBottomOfMessages();
+        }
+
+
+        //public void RaiseInformation(string message, bool addNewLine = false)
+        //{
+        //    if (OnMessageRaised != null)
+        //    {
+        //        OnMessageRaised(this, new GameMessageEventArgs(message, addNewLine));
+        //    }
+        //}
+
+        //public void RaiseWarning(string message, Color color, bool addNewLine = false)
+        //{
+        //    if (OnMessageRaised != null)
+        //    {
+        //        OnMessageRaised(this, new GameMessageEventArgs(message, color, addNewLine));
+        //    }
+        //}
+
+        public void DisplayMessage(object sender, GameMessageEventArgs gameMessageEventArgs)
+        {
+            if (gameMessageEventArgs.Color == null)
+            {
+                rtbMessages.AppendText(gameMessageEventArgs.Message + Environment.NewLine);
+            }
+            else
+            {
+                rtbMessages.AppendText(gameMessageEventArgs.Message, gameMessageEventArgs.Color, true);
+            }
+
+            if (gameMessageEventArgs.AddNewLine == true)
+            {
+                rtbMessages.AppendText(Environment.NewLine);
+            }
+
+            //ScrollToBottomOfMessages();
         }
 
         private void DeleteMessagesRowOverflow()
@@ -70,7 +115,7 @@ namespace SuperAdventure
                 }
                 rtbMessages.ReadOnly = true;
             }
-            ScrollToBottomOfMessages();
+            //ScrollToBottomOfMessages();
         }
 
         private void SelectMessagesIndex()
@@ -278,12 +323,17 @@ namespace SuperAdventure
         {
             dgvQuests.DefaultCellStyle.SelectionBackColor = dgvQuests.DefaultCellStyle.BackColor;
             dgvQuests.DefaultCellStyle.SelectionForeColor = dgvQuests.DefaultCellStyle.ForeColor;
+            dgvQuests.ColumnHeadersBorderStyle = DataGridViewHeaderBorderStyle.Single;
+            dgvQuests.CellBorderStyle = DataGridViewCellBorderStyle.Single;
+            dgvQuests.EnableHeadersVisualStyles = false;
+            dgvQuests.GridColor = Color.Gray;
+
             dgvQuests.RowHeadersVisible = false;
             dgvQuests.ColumnCount = 2;
             dgvQuests.Columns[0].Name = "Name";
-            dgvQuests.Columns[0].Width = 198;
+            dgvQuests.Columns[0].Width = 239;
             dgvQuests.Columns[1].Name = "Completed";
-            dgvQuests.Columns[1].Width = 110;
+            dgvQuests.Columns[1].Width = 70;
         }
 
         public void UpdateInventoryList()


### PR DESCRIPTION
- Added GameMessageEventArgs.cs
creates standard and colored messages

- Added MessageMessageUtilities.cs
contains EventHandler<GameMessageEventArgs> OnMessageRaised
RaiseMessage, RaiseWarning, RaiseInfo

- Added DisplayMessage() in the WinForms SuperAdvanture.cs

Swapped from direct RichTextBox calls to event based messaging in CombatMessager and QuestMessager.
Any class that uses this messaging method needs to inherit from MessageUtilities and make object.DisplayMessage() subscribe to OnMessageRaised in the constructor.